### PR TITLE
(opera) Fixed silent uninstall

### DIFF
--- a/automatic/opera/tools/chocolateyUninstall.ps1
+++ b/automatic/opera/tools/chocolateyUninstall.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName         = 'opera'
+$softwareNamePattern = 'Opera*'
+
+[array] $key = Get-UninstallRegistryKey $softwareNamePattern
+if ($key.Count -eq 1) {
+    $key | % {
+        $packageArgs = @{
+            packageName            = $packageName
+            silentArgs             = "/uninstall /silent"
+            fileType               = 'EXE'
+            validExitCodes         = @(0)
+            file                   = $_.UninstallString.replace(' /uninstall', '').trim('"')
+        }
+        Uninstall-ChocolateyPackage @packageArgs
+    }
+}
+elseif ($key.Count -eq 0) {
+    Write-Warning "$packageName has already been uninstalled by other means."
+}
+elseif ($key.Count -gt 1) {
+    Write-Warning "$($key.Count) matches found!"
+    Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+    Write-Warning "Please alert package maintainer the following keys were matched:"
+    $key | % {Write-Warning "- $($_.DisplayName)"}
+}


### PR DESCRIPTION
## Description
I fixed issue #1054 - opera package can be silently uninstalled now.

## Motivation and Context
It solves the one of the most important things - now package is fully silent, like it's recommended in guide lines.

Fixes #1054

## How Has this Been Tested?
I packed package, installed it and of course I tested uninstalling it and it now silently uninstalls.

Tested on Windows 10, version 1803

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).